### PR TITLE
Ssp 67

### DIFF
--- a/src/components/chat.js
+++ b/src/components/chat.js
@@ -286,7 +286,7 @@ export default Vue.extend({
         this.chatConversation.push(chat)
         this.chatBotIframe.contentWindow.document.getElementById('spinner').style.display = 'none'
         this.disableQInput = false
-        
+ 
         if (response.dialogState === 'Fulfilled') {
           const text = { message: 'Ik ben altijd bereikbaar, mocht je nog meer vragen hebben. Reset de chat om een nieuwe vraag te stellen.'}
           this.showBotReponse(text)
@@ -296,6 +296,8 @@ export default Vue.extend({
         } else if(!this.status) {
           this.storeConversation.push(data)
           LocalStorage.set('conversation', this.storeConversation)
+        } else if(this.status) {
+          this.disableQInput = true
         }
 
         setTimeout(() => {
@@ -347,9 +349,6 @@ export default Vue.extend({
     async sendUserResponse(response){
       if(response.length < 1000 && !this.status){
         await this.sendToLex(response)
-      } else if(this.status) {
-        this.resetChat()
-        this.status = false
       }
     },
     sendValue(response){

--- a/src/components/chat.js
+++ b/src/components/chat.js
@@ -360,7 +360,7 @@ export default Vue.extend({
     self.createElement = createElement
 
     // header of the widget with avatar
-    const header = getHeader(createElement, self.toggleButtonChat)
+    const header = getHeader(createElement, self.toggleButtonChat, self.resetChat)
     // chat wrapper for the chat-messages, options and the q-spinners dots
     const body = getBody(createElement, self.chatConversation, self.btnOptions)
     // messages exchanged

--- a/src/components/render.js
+++ b/src/components/render.js
@@ -54,7 +54,7 @@ const getButton = (createElement, toggleButtonChat) => {
 }
 
 // getHeader()
-const getHeader = (createElement, toggleButtonChat) => {
+const getHeader = (createElement, toggleButtonChat, resetChat) => {
   const imgHeader = createElement('img', { attrs: { src: 'https://i.pinimg.com/originals/7d/9b/1d/7d9b1d662b28cd365b33a01a3d0288e1.gif' } })
   const qAvatarHeader = createElement('q-avatar', [imgHeader])
   const qItemSectionAvatar = createElement('q-item-section', { props: { avatar: true } }, [qAvatarHeader])
@@ -63,6 +63,17 @@ const getHeader = (createElement, toggleButtonChat) => {
   const title = createElement('q-item-label', { class: 'text-h5' }, 'Chatbot')
   const subTitle = createElement('q-item-label', { props: { caption: true } }, 'Online')
   const qItemSectionText = createElement('q-item-section', [title, subTitle])
+
+  const resetIcon = createElement('q-btn', {
+    props: {
+      round: true,
+      flat: true,
+      icon: 'autorenew'
+    },
+    on: {
+      click: resetChat
+    }
+  })
 
   const closeIcon = createElement('q-btn', {
     props: {
@@ -75,7 +86,7 @@ const getHeader = (createElement, toggleButtonChat) => {
     }
   })
 
-  const header = createElement('q-item', { class: 'q-py-md' }, [qItemSectionAvatar, qItemSectionText, closeIcon])
+  const header = createElement('q-item', { class: 'q-py-md' }, [qItemSectionAvatar, qItemSectionText, resetIcon, closeIcon])
 
   return header
 }

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ let lexUserId = null
 const timeSendMessage = LocalStorage.getItem('time')
 const currentTime = Date.now()
 const unit = 'minutes'
-const timeSession = 15
+const timeSession = 60
 
 const diff = date.getDateDiff(currentTime, timeSendMessage, unit)
 


### PR DESCRIPTION
1. Resetting the chat should be a user option available at al times. The user might make a mistake and want to start over. This should always be possible thru a persistent recycle button next to the close button.

2. After the chat flow has been concluded (positive or negative) the chat bot should state that the user can ask a different question by resetting the chat: 'Ik ben altijd bereikbaar, mocht je nog meer vragen hebben. Reset de chat om een nieuwe vraag te stellen.' The input field should be blocked after this message and should not contain any predefined text.

3. The chat should be automatically reset by the chat bot after a hour. The user does not need to be notified about the reset.

[Link of issue ](https://simactrianglebv.atlassian.net/browse/SSP-68)