### PR TITLE
Ssp 70 - Make a counter to count the characters in the input field of the chat bot

### DIFF
--- a/src/components/chat.js
+++ b/src/components/chat.js
@@ -32,7 +32,7 @@ export default Vue.extend({
       wrapper: null,
       wrapperButton: null,
       chatBotWidth: '370px',
-      chatBotHeight: '680px',
+      chatBotHeight: '700px',
       chatBotRoom: null,
       chatBotIframe: null,
       disableQInput: false,
@@ -182,6 +182,8 @@ export default Vue.extend({
 
       this.setConfiguration()
       this.initChat()
+
+      this.status = false
     },
     clearStorage(){
       this.storeConversation = []
@@ -265,6 +267,9 @@ export default Vue.extend({
 
       this.chatBotIframe.contentWindow.document.getElementById('spinner').style.display = 'block'
       this.disableQInput = true
+
+      this.chatBotIframe.contentWindow.document.querySelector('.q-field__counter').style.color = 'black'
+      this.chatBotIframe.contentWindow.document.querySelector('.q-field__counter').style.opacity = '0.5'
     },
     async showBotReponse(response) {
       this.chatBotIframe.contentWindow.document.getElementById('spinner').style.display = 'block'

--- a/src/components/chat.js
+++ b/src/components/chat.js
@@ -32,7 +32,7 @@ export default Vue.extend({
       wrapper: null,
       wrapperButton: null,
       chatBotWidth: '370px',
-      chatBotHeight: '680px',
+      chatBotHeight: '690px',
       chatBotRoom: null,
       chatBotIframe: null,
       disableQInput: false,
@@ -350,8 +350,16 @@ export default Vue.extend({
       }, 1800)
     },
     async sendUserResponse(response){
-      if(response.length < 1000){
+      if(response.length < 1024){
         await this.sendToLex(response)
+      }
+    },
+    sendValue(response){
+      this.chatInput = response
+      if(this.chatInput.length >= 1014){
+        this.chatBotIframe.contentWindow.document.querySelector('.counter').style.color = 'red'
+      } else {
+        this.chatBotIframe.contentWindow.document.querySelector('.counter').style.color = 'black'
       }
     }
   },
@@ -364,7 +372,7 @@ export default Vue.extend({
     // chat wrapper for the chat-messages, options and the q-spinners dots
     const body = getBody(createElement, self.chatConversation, self.btnOptions)
     // messages exchanged
-    const messageInput = getmessageInput(createElement, self.chatInput, self.sendUserResponse, self.disableQInput)
+    const messageInput = getmessageInput(createElement, self.chatInput, self.sendUserResponse, self.disableQInput, self.sendValue)
     //start chat again button if the 5 minutes are passed
     const resetChatButton = getResetChatButton(createElement, self.resetChat)
     //Toggle button, to open the chat

--- a/src/components/chat.js
+++ b/src/components/chat.js
@@ -32,7 +32,7 @@ export default Vue.extend({
       wrapper: null,
       wrapperButton: null,
       chatBotWidth: '370px',
-      chatBotHeight: '690px',
+      chatBotHeight: '700px',
       chatBotRoom: null,
       chatBotIframe: null,
       disableQInput: false,

--- a/src/components/chat.js
+++ b/src/components/chat.js
@@ -357,9 +357,10 @@ export default Vue.extend({
     sendValue(response){
       this.chatInput = response
       if(this.chatInput.length >= 1014){
-        this.chatBotIframe.contentWindow.document.querySelector('.counter').style.color = 'red'
+        this.chatBotIframe.contentWindow.document.querySelector('.q-field__counter').style.color = 'red'
       } else {
-        this.chatBotIframe.contentWindow.document.querySelector('.counter').style.color = 'black'
+        this.chatBotIframe.contentWindow.document.querySelector('.q-field__counter').style.color = 'black'
+        this.chatBotIframe.contentWindow.document.querySelector('.q-field__counter').style.opacity = '0.5'
       }
     }
   },

--- a/src/components/iframeHeader.js
+++ b/src/components/iframeHeader.js
@@ -48,13 +48,6 @@ const iframeHeader = `
 #message-input {
   border-top: 1px solid rgb(238, 238, 238);
   border-bottom: 1px solid rgb(238, 238, 238);
-  padding-bottom: 25px;
-}
-
-.counter {
-  float: right;
-  font-size: 10px;
-  padding-top: 2px;
 }
 
 .footer {

--- a/src/components/iframeHeader.js
+++ b/src/components/iframeHeader.js
@@ -48,6 +48,13 @@ const iframeHeader = `
 #message-input {
   border-top: 1px solid rgb(238, 238, 238);
   border-bottom: 1px solid rgb(238, 238, 238);
+  padding-bottom: 25px;
+}
+
+.counter {
+  float: right;
+  font-size: 10px;
+  padding-top: 2px;
 }
 
 .footer {

--- a/src/components/render.js
+++ b/src/components/render.js
@@ -110,6 +110,7 @@ const getmessageInput = (createElement, chatInput, sendUserResponse, disableQInp
     on: {
       input: function (event) {
         chatInput = event
+        sendValue(event)
       },
       click: function (event) {
         if (chatInput.length >= 1) {
@@ -122,6 +123,9 @@ const getmessageInput = (createElement, chatInput, sendUserResponse, disableQInp
   // Inputfield of the chat
   const qInput = createElement('q-input', {
     props: {
+      'bottom-slots': true,
+      counter: true,
+      maxlength: 1024,
       dense: true,
       borderless: true,
       disable: disableQInput,
@@ -143,10 +147,7 @@ const getmessageInput = (createElement, chatInput, sendUserResponse, disableQInp
     }
   }, [sendIcon])
 
-  let counter = chatInput.length + '/1020'
-  const messageCounter = createElement('span', {class: 'counter'}, [counter])
-
-  const messageInput = createElement('q-card-section', { attrs: { id: 'message-input' }, class: 'q-py-sm' }, [qInput, messageCounter])
+  const messageInput = createElement('q-card-section', { attrs: { id: 'message-input' }, class: 'q-py-sm' }, [qInput])
   return messageInput
 }
 

--- a/src/components/render.js
+++ b/src/components/render.js
@@ -98,14 +98,14 @@ const getBody = (createElement, chatConversation, btnOptions) => {
 }
 
 //input
-const getmessageInput = (createElement, chatInput, sendUserResponse, disableQInput) => {
+const getmessageInput = (createElement, chatInput, sendUserResponse, disableQInput, sendValue) => {
   const sendIcon = createElement('q-btn', {
     class: 'text-grey-4',
     props: {
       icon: 'send',
       round: true,
       dense: true,
-      flat: true
+      flat: true,
     },
     on: {
       input: function (event) {
@@ -118,12 +118,14 @@ const getmessageInput = (createElement, chatInput, sendUserResponse, disableQInp
       }
     }
   })
+
   // Inputfield of the chat
   const qInput = createElement('q-input', {
     props: {
       dense: true,
       borderless: true,
-      disable: disableQInput
+      disable: disableQInput,
+      value: chatInput,
     },
     attrs: {
       placeholder: 'Type jouw bericht in'
@@ -131,6 +133,7 @@ const getmessageInput = (createElement, chatInput, sendUserResponse, disableQInp
     on: {
       input: function (event) {
         chatInput = event
+        sendValue(event)
       },
       keyup: function (event) {
         if (event.keyCode === 13 && chatInput.length >= 1) {
@@ -139,7 +142,11 @@ const getmessageInput = (createElement, chatInput, sendUserResponse, disableQInp
       }
     }
   }, [sendIcon])
-  const messageInput = createElement('q-card-section', { attrs: { id: 'message-input' }, class: 'q-py-sm' }, [qInput])
+
+  let counter = chatInput.length + '/1020'
+  const messageCounter = createElement('span', {class: 'counter'}, [counter])
+
+  const messageInput = createElement('q-card-section', { attrs: { id: 'message-input' }, class: 'q-py-sm' }, [qInput, messageCounter])
   return messageInput
 }
 


### PR DESCRIPTION
When a user has the option to freely input text in the input field of the chat add a counter to count the characters. The counter consists of the inputted characters and the max number of characters allowed like this:{characters input}/{max number of characters}

 When the max number of characters is reached more input is not allowed. The user does not get extra feedback that the max amount of characters has been reached.

When the input characters are within 10 of the max number of characters turn the input characters number red.

 When a text is pasted which contains more than the max amount of characters only the characters from till max amount allowed are pasted in the input field. 

[Link issue](https://simactrianglebv.atlassian.net/browse/SSP-70)