### PR TITLE
fix save chat history

### DIFF
--- a/src/components/chat.js
+++ b/src/components/chat.js
@@ -291,7 +291,12 @@ export default Vue.extend({
         this.disableQInput = false
         this.disableReset = false
 
-        if (response.dialogState === 'Fulfilled') {
+        let intentName = response.intentName
+
+        if (intentName === 'bridgeIntent') {
+          this.clearStorage()
+          this.disableQInput = true
+        } else if (response.dialogState === 'Fulfilled' && intentName === 'contactus'){
           this.clearStorage()
           this.disableQInput = true
         } else {


### PR DESCRIPTION
After 4 non-valid answers to a question the chat bot should ask if the user wants to continue the chat: 'Het lijkt erop dat we elkaar niet goed begrijpen. Wil je doorgaan met de chat?' (Ja/Nee) If yes is chosen return to the flow of the last question. But if you refresh the page, the chat history will be deleted, while the original flow is intact.

Solution:
The chathistory must still be in, after the user has press JA

