### PR TITLE
Fix ssp 76 send error message

### DIFF
--- a/src/components/chat.js
+++ b/src/components/chat.js
@@ -236,9 +236,10 @@ export default Vue.extend({
           const chat = this.createElement('q-chat-message', {
             props: data
           })
-          
+
           this.chatConversation.push(chat)
           this.disableReset = false
+          this.disableQChip = true
           this.chatBotIframe.contentWindow.document.getElementById('spinner').style.display = 'none'
         }
 

--- a/src/components/chat.js
+++ b/src/components/chat.js
@@ -227,7 +227,7 @@ export default Vue.extend({
         if(err){
           const data = {
             avatar: 'https://cdn.dribbble.com/users/690291/screenshots/3507754/untitled-1.gif',
-            text: ['Sorry er ging iets mis met uw bericht, Reset de chat om een nieuwe vraag te stellen.'],
+            text: ['Sorry er ging iets mis. Reset de chat om een nieuwe vraag te stellen.'],
             from: 'bot',
             sent: false,
             name: 'Bot Alice',

--- a/src/components/chat.js
+++ b/src/components/chat.js
@@ -222,6 +222,26 @@ export default Vue.extend({
       }
 
       await this.lexruntime.postText(params, async (err, response) => {
+        if(err){
+          const data = {
+            avatar: 'https://cdn.dribbble.com/users/690291/screenshots/3507754/untitled-1.gif',
+            text: ['Sorry er ging iets mis met uw bericht, Reset de chat om een nieuwe vraag te stellen.'],
+            from: 'bot',
+            sent: false,
+            name: 'Bot Alice',
+            bgColor: 'red-9',
+            textColor: 'white'
+          }
+    
+          const chat = this.createElement('q-chat-message', {
+            props: data
+          })
+          
+          this.chatConversation.push(chat)
+          this.disableReset = false
+          this.chatBotIframe.contentWindow.document.getElementById('spinner').style.display = 'none'
+        }
+
         if (response) {
           const sessionId = LocalStorage.getItem('session')
           if(response.sessionId != sessionId && this.chatConversation.length >= 1) {


### PR DESCRIPTION
**Problem**
During the chat conversation, sometimes the chat doesn't get a proper response of the AWS lex. 
The client (front-end) need to handle gracefully thrown error from the back-end.

**Desired solution**
If this type of error occurs, the user get a message: 'Sorry er ging iets mis, Reset de chat om een nieuwe vraag te stellen.' The user can not write a new message and need to press on the reset button. 

[Issue](https://simactrianglebv.atlassian.net/browse/SSP-76)